### PR TITLE
Add Procfile for deploy to heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'http://rubygems.org'
 gem 'rails', '4.2.3'
 # Use sqlite3 as the database for Active Record
 gem 'pg'
+gem 'puma'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    puma (2.11.3)
+      rack (>= 1.1, < 2.0)
     rack (1.6.4)
     rack-cors (0.4.0)
     rack-test (0.6.3)
@@ -139,6 +141,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   pg
   pry
+  puma
   rack-cors
   rails (= 4.2.3)
   sdoc (~> 0.4.0)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C config/puma.rb

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,15 @@
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
+threads threads_count, threads_count
+
+preload_app!
+
+rackup      DefaultRackup
+port        ENV['PORT']     || 3000
+environment ENV['RACK_ENV'] || 'development'
+
+on_worker_boot do
+  # Worker specific setup for Rails 4.1+
+  # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
+  ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
We might have to play around with this a bit, but currently Heroku is just running your app with the basic WEBrick server. They recommend Puma for a production app.

## Documentation on Puma server on Heroku
https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server

## Running app locally with Profile
https://devcenter.heroku.com/articles/heroku-local

## Other Related Docs
https://devcenter.heroku.com/articles/procfile
https://devcenter.heroku.com/articles/process-model
https://devcenter.heroku.com/articles/concurrency-and-database-connections#threaded-servers